### PR TITLE
Add heartbeat and other settings to connection

### DIFF
--- a/src/Kdyby/RabbitMq/DI/RabbitMqExtension.php
+++ b/src/Kdyby/RabbitMq/DI/RabbitMqExtension.php
@@ -81,6 +81,15 @@ class RabbitMqExtension extends Nette\DI\CompilerExtension
 		'qos' => [],
 		'idleTimeout' => NULL,
 		'autoSetupFabric' => NULL, // inherits from `rabbitmq: autoSetupFabric:`
+        	'insist' => false,
+		'login_method' => 'AMQPLAIN',
+		'login_response' => null,
+		'locale' => 'en_US',
+		'connection_timeout' => 3,
+		'read_write_timeout' => 3,
+		'context' => null,
+		'keepalive' => false,
+		'heartbeat' => 60,
 	];
 
 	/**
@@ -251,7 +260,16 @@ class RabbitMqExtension extends Nette\DI\CompilerExtension
 					$config['port'],
 					$config['user'],
 					$config['password'],
-					$config['vhost']
+					$config['vhost'],
+					$config['insist'],
+					$config['login_method'],
+					$config['login_response'],
+					$config['locale'],
+					$config['connection_timeout'],
+					$config['read_write_timeout'],
+					$config['context'],
+					$config['keepalive'],
+					$config['heartbeat'],
 				]);
 
 			$this->connectionsMeta[$name] = [


### PR DESCRIPTION
I need heartbeat, because if process die, conection still run and messages end with unacked state.